### PR TITLE
RF Upload Component

### DIFF
--- a/src/parse_json_to_html.js
+++ b/src/parse_json_to_html.js
@@ -18,7 +18,9 @@ export function convertJsonToHtml(inputFile) {
     convertJsonComponentToHtmlDiv(component),
   );
 
-  divComponents.push(createUploadedDocumentsDiv(uploadComponent));
+  if (uploadComponent) {
+    divComponents.push(createUploadedDocumentsDiv(uploadComponent));
+  }
 
   const scriptComponents = jsonComponents
     .filter((component) => component.type === "upload")


### PR DESCRIPTION
Pois a implementação anterior processava e anexa elementos e scripts relacionados ao componente de upload, independentemente da presença de um componente de upload no JSON de entrada, resultado em erro.